### PR TITLE
Introduce Decorators

### DIFF
--- a/examples/plugins/hello-world-es6.plugin.ts
+++ b/examples/plugins/hello-world-es6.plugin.ts
@@ -1,0 +1,11 @@
+import { RemixPlugin, Plugin } from 'remix-plugin'
+
+
+class HelloWorldPlugin extends RemixPlugin {
+  log() {
+    return 'ES6 hello world'
+  }
+}
+
+/** ES6 Version of the Hello world Plugin using the "Plugin" decorator */
+export class Es6HelloWorldPlugin extends Plugin({ type: 'es6-hello-world' })(HelloWorldPlugin) {}

--- a/examples/plugins/hello-world.plugin.ts
+++ b/examples/plugins/hello-world.plugin.ts
@@ -1,18 +1,13 @@
-import { ModuleManager, RemixPlugin } from 'remix-plugin'
+import { RemixPlugin, Plugin } from 'remix-plugin'
 
+@Plugin({
+  type: 'hello-world'
+})
 export class HelloWorldPlugin extends RemixPlugin {
 
-  protected manager: ModuleManager
-
-  constructor() {
-    super('hello-world')
+  log() {
+    return 'hello world'
   }
 
-  public activate(manager: ModuleManager) {
-    this.manager = manager
-
-    this.addMethod('log', () => 'Hello World')
-  }
-
-  public deactivate() {}
 }
+

--- a/examples/plugins/index.ts
+++ b/examples/plugins/index.ts
@@ -1,1 +1,2 @@
 export * from './hello-world.plugin'
+export * from './hello-world-es6.plugin'

--- a/src/plugins/decorator.ts
+++ b/src/plugins/decorator.ts
@@ -1,0 +1,21 @@
+import { ModuleManager } from '../module-manager'
+
+/**
+ * Decorator around plugin classes
+ * @param config Config about the plugin
+ */
+export function Plugin(config: {type: string}) {
+  return function<T extends {new(...args: any[])}>(constructor: T) {
+
+    return class extends constructor {
+      public type = config.type
+
+      activate(manager: ModuleManager) {
+        // For each method of the plugin add it to the manager
+        Object.keys(constructor.prototype).forEach(key => {
+          manager.addMethod(config.type, key, constructor.prototype[key])
+        })
+      }
+    }
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
+export * from './decorator'
 export * from './webview.plugin'

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -3,18 +3,17 @@ import { ModuleManager } from '../module-manager'
 
 export abstract class RemixPlugin {
 
-  protected abstract manager: ModuleManager
-
-  constructor(public type: string) {}
+  public type: string
+  protected manager: ModuleManager
 
   /**
    * Activate lazily the plugin
    * @param manager The global module Manager
    */
-  public abstract async activate(manager: ModuleManager)
+  public async activate(manager: ModuleManager) {}
 
   /** Deactivate the plugin and all the methods it exposes */
-  public abstract async deactivate()
+  public async deactivate() {}
 
   /**
    * Export a method to the manager

--- a/tests/manager.ts
+++ b/tests/manager.ts
@@ -1,5 +1,5 @@
 import { ModuleManager, PluginManager } from 'remix-plugin'
-import { HelloWorldPlugin } from 'examples'
+import { HelloWorldPlugin, Es6HelloWorldPlugin } from 'examples'
 
 let moduleManager: ModuleManager
 let pluginManager: PluginManager
@@ -14,10 +14,10 @@ test('Create module manager', () => expect(moduleManager).toBeDefined())
 test('Create plugin manager', () => expect(pluginManager).toBeDefined())
 
 describe('Test Hello World Plugin', () => {
-  let helloWorld: HelloWorldPlugin
+  let helloWorld: Es6HelloWorldPlugin
 
   beforeEach(() => {
-    helloWorld = new HelloWorldPlugin()
+    helloWorld = new Es6HelloWorldPlugin()
   })
 
   test('Register', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
+    "experimentalDecorators": true,
     "target": "es5",
     "typeRoots": ["node_modules/@types"],
     "lib": ["dom", "es2018"],


### PR DESCRIPTION
Decorators are common in Typescript but are ES7.
You can use them in ES6 with no problem ([see](https://github.com/ethereum/remix-plugin/compare/testing?expand=1#diff-e3726204deed673b11e635576000db94))
It makes the plugin interface much clearer and helps a lot with types: We will be able to have dynamic typing.