### PR TITLE
Reserved Keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-plugin",
-  "version": "0.0.1-alpha.42",
+  "version": "0.0.1-alpha.43",
   "description": "Ethereum IDE and tools for the web",
   "contributors": [
     {

--- a/src/extension-client/remix-extension.ts
+++ b/src/extension-client/remix-extension.ts
@@ -8,17 +8,17 @@ export interface RemixExtensionOptions {
   useCustomBootStrapTheme: boolean
 }
 
-export interface Notifications {
+interface Notifications {
   [name: string]: {
     [key: string]: (...payload: any[]) => void
   }
 }
 
-export interface PendingRequests {
+interface PendingRequests {
   [id: number]: (payload: any, error?: Error) => void
 }
 
-export interface Theme {
+interface Theme {
   url: string
   quality: 'dark' | 'light'
 }

--- a/src/extension-client/remix-extension.ts
+++ b/src/extension-client/remix-extension.ts
@@ -8,6 +8,16 @@ export interface RemixExtensionOptions {
   useCustomBootStrapTheme: boolean
 }
 
+export interface Notifications {
+  [name: string]: {
+    [key: string]: (...payload: any[]) => void
+  }
+}
+
+export interface PendingRequests {
+  [id: number]: (payload: any, error?: Error) => void
+}
+
 export interface Theme {
   url: string
   quality: 'dark' | 'light'
@@ -24,14 +34,8 @@ export class RemixExtension<T extends Api = any> {
   private devMode: DevMode
   private source: Window
   private origin: string
-  private notifications: {
-    [name: string]: {
-      [key: string]: (...payload: any[]) => void
-    }
-  } = {}
-  private pendingRequests: {
-    [id: number]: (payload: any, error?: Error) => void
-  } = {}
+  private notifications: Notifications = {}
+  private pendingRequests: PendingRequests = {}
   private id = 0
   private handshake: () => any
   protected currentRequest: PluginRequest

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,0 +1,25 @@
+import { PluginProfile, Api } from "./types"
+
+export const services = {
+  'theme': ['switchTheme']
+}
+
+export function addServices<T extends Api>(pluginProfile: PluginProfile<T>) {
+  const serviceKeys = Object.keys(services)
+  const profile = {...pluginProfile}
+  if (serviceKeys.includes(profile.name)) {
+    throw new Error(`${profile.name} is a reserved keyword, please use another name for your plugin`)
+  }
+
+  if (!profile.notifications) profile.notifications = {}
+  serviceKeys.forEach(service => {
+    if (profile.notifications[service]) {
+      throw new Error(`${profile.name} plugin should not listen on ${service}. This is a reserved keyword`)
+    }
+    profile.notifications = {
+      ...profile.notifications,
+      [service]: services[service]
+    }
+  })
+  return profile
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,13 +57,28 @@ export interface ModuleProfile<T extends Api = any> {
 }
 
 export interface PluginProfile<T extends Api = any> extends ModuleProfile<T> {
+  url: string
+  hash?: string
+  location?: string // The name of the module used to load the iframe in
+  version?: string
+  contributors?: {
+    name: string,
+    email: string,
+    url: string
+  }
+  homepage?: string
+  bugs?: {
+    url: string,
+    email: string
+  }
+  repository?: {
+    type: 'git',
+    url: string
+  }
   required?: false
   notifications?: {
     [name: string]: string[]
   }
-  url: string
-  hash?: string
-  location?: string // The name of the module used to load the iframe in
 }
 
 ////////////////////////

--- a/tests/extension.ts
+++ b/tests/extension.ts
@@ -17,7 +17,6 @@ const handshake = {
   data: {
     action: 'request',
     key: 'handshake',
-    payload: { theme: 'my-theme' }
   }
 }
 

--- a/tests/keywords.ts
+++ b/tests/keywords.ts
@@ -1,0 +1,32 @@
+import { PluginProfile } from "../src"
+import { Plugin } from '../src/engine/plugin'
+import { services as serviceMap } from '../src/services'
+
+const ThemeProfile: PluginProfile<any> = {
+  name: 'theme',
+  url: ''
+}
+
+const NormalProfile: PluginProfile<any> = {
+  name: 'normal',
+  url: ''
+}
+
+describe('Keywords', () => {
+  test('Should warn not to use keyword', () => {
+    try {
+      const plugin = new Plugin(ThemeProfile)
+    } catch (err) {
+      expect(err.message).toMatch(`${ThemeProfile.name} is a reserved keyword, please use another name for your plugin`)
+    }
+  })
+
+  test('Should add services in notifications', () => {
+    const plugin = new Plugin(NormalProfile)
+    if (!plugin.profile.notifications) throw new Error('notifications should be defined')
+    const notifications = Object.keys(plugin.profile.notifications)
+    const services = Object.keys(serviceMap)
+    const notificationsHasAllServices = services.every(service => notifications.includes(service))
+    expect(notificationsHasAllServices).toBe(true)
+  })
+})


### PR DESCRIPTION
Solve :
- [issue#45](https://github.com/ethereum/remix-plugin/issues/45) by checking that plugin profile are not named under a reserved name, and that they don't already define these keyword in `notification`.
- [issue#46](https://github.com/ethereum/remix-plugin/issues/46) by adding all services into the notification profile of the plugin.

Partially solve : 
- [issue#32](https://github.com/ethereum/remix-plugin/issues/32) by defining one mandatory service to listen to.