### PR TITLE
fix #86. Broken link to Etherscan Verification example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Remix plugin helps you extends the Remix IDE. The goal is to give access of all the features inside Remix and make them available for Ethereum Developers.
 
-Remix Plugin can be use (but not only) for : 
+Remix Plugin can be use (but not only) for :
 - Educational Purpose.
 - Smart-Contract library managment.
 - Language Service.
@@ -18,18 +18,18 @@ This version is still a work in progress and some breaks may be expected (especi
 
 ## Getting Started
 
-Installation : 
+Installation :
 ```bash
 npm install remix-plugin
 ```
 
-or with a unpkg : 
+or with a unpkg :
 ```html
 <script src="https://unpkg.com/remix-plugin"></script>
 ```
 
 ### Plugin Client
-The plugin client is how you connect your plug to remix.
+The plugin client is how you connect your plugin to remix.
 
 To import ( the ES6 way) with NPM use:
 ```javascript
@@ -61,17 +61,17 @@ client.call('fileManager', 'setFile', path, content)   // Without customApi
 #### DevMode
 Plugins communicate with the IDE through the `postMessage` API. It means that `PluginClient` needs to know the origin of your IDE.
 
-If you're developping a plugin with your IDE running on `localhost` you'll need to specify the port on which your IDE runs : 
+If you're developing a plugin with your IDE running on `localhost` you'll need to specify the port on which your IDE runs :
 ```typescript
 const devMode = { port: 8080 } // By default Remix IDE runs on port 8080
 const client = createIframeClient({ devMode })
 ```
 
 ### Examples
-You can find examples of plugins here : 
+You can find examples of plugins here :
 - [Hello World](./examples/plugins/hello-world)
 - [Lit Element](./examples/plugins/ethdoc)
-- [Etherscan Verification](./examples/etherscan-verify)
+- [Etherscan Verification](./examples/plugins/etherscan)
 
 ---
 ## Test inside Remix IDE
@@ -101,12 +101,12 @@ await client.onload()
 ```
 
 ### Events
-To listen to an event you need to provide the name of the plugin your listening on, and the name of the event : 
+To listen to an event you need to provide the name of the plugin you're listening on, and the name of the event :
 ```javascript
 client.on(/* pluginName */, /* eventName */, ...arguments)
 ```
 
-For exemple if you want to listen to Solidity compilation : 
+For exemple if you want to listen to Solidity compilation :
 ```javascript
 client.on('solidity', 'compilationFinished', (target, source, version, data) => {
     /* Do Something on Compilation */
@@ -116,14 +116,14 @@ client.on('solidity', 'compilationFinished', (target, source, version, data) => 
 
 > See all available event [below](#api).
 
-### Call 
-You can call some methods exposed by the IDE with with the method `call`. You need to provide the name of the plugin, the name of the method, and the arguments of the methods : 
+### Call
+You can call some methods exposed by the IDE with with the method `call`. You need to provide the name of the plugin, the name of the method, and the arguments of the methods :
 ```javascript
 await client.call(/* pluginName */, /* methodName */, ...arguments)
 ```
 > Note: `call` is alway Promise
 
-For example if you want to upsert the current file : 
+For example if you want to upsert the current file :
 ```typescript
 async function upsertCurrentFile(content: string) {
   const path = await client.call('fileManager', 'getCurrentFile')
@@ -139,7 +139,7 @@ Your plugin can emit events that other plugins can listen on.
 client.emit(/* eventName */, ...arguments)
 ```
 
-Let's say your plugin build a deploy a Readme for your contract on IPFS : 
+Let's say your plugin build deploys a Readme for your contract on IPFS :
 ```javascript
 async function deployReadme(content) {
   const [ result ] = await ipfs.files.add(content);
@@ -156,7 +156,7 @@ async function deployReadme(content) {
 ### Testing your plugin
 You can test your plugin direcly on the [alpha version of Remix-IDE](https://remix-alpha.ethereum.org). Go to the `pluginManager` (plug icon in the sidebar), and click "Connect to a Local Plugin".
 
-Here you can add : 
+Here you can add :
 - A name : this is the name used by other plugin to listen to your events.
 - A displayName : Used by the IDE.
 - The url : May be a localhost for testing.
@@ -167,9 +167,9 @@ Here you can add :
 This is not available now.
 
 # API
-Your plugin can interact with other plugins through the API. `remix-plugin` provide a set of default plugins integrated inside the Remix IDE. Some of the APIs have to be used with caution. So they might ask the permission of the user.  
+Your plugin can interact with other plugins through the API. `remix-plugin` provide a set of default plugins integrated inside the Remix IDE. Some of the APIs have to be used with caution. So they might ask the permission of the user.
 
- 
+
 ## Remix Api
 Click on the name of the api to get the full documentation.
 
@@ -184,15 +184,15 @@ Click on the name of the api to get the full documentation.
 > This API is a Work In Progress and will be extended in the future.
 
 ## Status
-Every plugin has a status object that can display notifications on the IDE. You can listen on a change of status from any plugin using `statusChanged` event : 
+Every plugin has a status object that can display notifications on the IDE. You can listen on a change of status from any plugin using `statusChanged` event :
 
 ```typescript
 client.listen('fileManager', 'statusChanged', (status: Status) => {
-  // Do Something 
+  // Do Something
 })
 ```
 
-The status object is used for displaying a notification. It looks like that : 
+The status object is used for displaying a notification. It looks like that :
 ```typescript
 interface Status {
   key: number | 'edited' | 'succeed' | 'loading' | 'failed' | 'none'  // Display an icon or number
@@ -203,7 +203,7 @@ interface Status {
 - If you want to remove a status use the `'none'` value for `key`.
 - If you don't define type, it would be the default value ('info' for Remix IDE).
 
-You can also change the status of your own plugin by emitting the same event : 
+You can also change the status of your own plugin by emitting the same event :
 ```typescript
 client.emit('statusChanged', { key: 'succeed', type: 'success', title: 'Documentation ready !' })
 ```
@@ -214,7 +214,7 @@ Remix is using [Bootstrap](https://getbootstrap.com/). For better User Experienc
 
 Remix will automatically create a `<link/>` tag in the header of your plugin with the current theme used. And it'll update the link each time the user change the theme.
 
-If you really want to use your own theme, you can use the `customTheme` flag in the option : 
+If you really want to use your own theme, you can use the `customTheme` flag in the option :
 ```typescript
 const client = createIframeClient({ customTheme: true })
 ```


### PR DESCRIPTION
Fixes the broken link pointed out in Issue #86, and minor spelling/grammar fixes in the readme