### PR TITLE
Add "allow-popups" to iframe attributes

### DIFF
--- a/projects/engine/src/plugin/iframe.ts
+++ b/projects/engine/src/plugin/iframe.ts
@@ -103,7 +103,7 @@ export class IframePlugin extends ViewPlugin {
     if (this.iframe.contentWindow) {
       throw new Error(`${this.name} plugin is already rendered`)
     }
-    this.iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms allow-top-navigation')
+    this.iframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-forms allow-top-navigation')
     this.iframe.setAttribute('seamless', 'true')
     this.iframe.src = this.profile.url
     // Wait for the iframe to load and handshake


### PR DESCRIPTION
I'm building a plugin which uses external links for the user to open.

## Current state for plugins/iframe
The iframe attributes currently include `allow-top-navigation`. This allows the user to open a link, but redirects the page, and closes Remix-IDE :-1: 

## Changes
This change to add "allow-popups" means the user can click a link without leaving Remix-IDE. :+1: 

Thanks for making the plugin process easy :zap: yall rock :guitar: , and I've had a lot of fun :100: 