### PR TITLE
Clarifies that sendTransaction is VM only, udapp call fix

### DIFF
--- a/doc/plugins/udapp.md
+++ b/doc/plugins/udapp.md
@@ -8,7 +8,7 @@ The udapp exposes an interface for interacting with the account and transaction.
 |Type     |Name                 |Description
 |---------|---------------------|--
 |_event_  |`newTransaction`     |Triggered when a new transaction has been sent.
-|_method_ |`sendTransaction`    |Send a transaction **only for testing networks**.
+|_method_ |`sendTransaction`    |Send a transaction **only for JavaScript VM**.
 |_method_ |`getAccounts`        |Get an array with the accounts exposed.
 |_method_ |`createVMAccount`    |Add an account if using the VM provider. 
 
@@ -17,7 +17,7 @@ The udapp exposes an interface for interacting with the account and transaction.
 ### Events
 `newTransaction`: Triggered when a new transaction has been sent.
 ```typescript
-client.solidity.on('newTransaction', (tx: RemixTx) => {
+client.udapp.on('newTransaction', (tx: RemixTx) => {
   // Do something
 })
 // OR
@@ -27,7 +27,7 @@ client.on('udapp', 'newTransaction', (tx: RemixTx) => {
 ```
 
 ### Methods
-`sendTransaction`: Send a transaction **only for testing networks**.
+`sendTransaction`: Send a transaction **only for JavaScript VM**.
 ```typescript
 const transaction: RemixTx = {
   gasLimit: '0x2710',

--- a/doc/plugins/udapp.md
+++ b/doc/plugins/udapp.md
@@ -8,7 +8,7 @@ The udapp exposes an interface for interacting with the account and transaction.
 |Type     |Name                 |Description
 |---------|---------------------|--
 |_event_  |`newTransaction`     |Triggered when a new transaction has been sent.
-|_method_ |`sendTransaction`    |Send a transaction **only for JavaScript VM**.
+|_method_ |`sendTransaction`    |Send a transaction **only for testing networks**.
 |_method_ |`getAccounts`        |Get an array with the accounts exposed.
 |_method_ |`createVMAccount`    |Add an account if using the VM provider. 
 
@@ -27,7 +27,7 @@ client.on('udapp', 'newTransaction', (tx: RemixTx) => {
 ```
 
 ### Methods
-`sendTransaction`: Send a transaction **only for JavaScript VM**.
+`sendTransaction`: Send a transaction **only for testing networks**.
 ```typescript
 const transaction: RemixTx = {
   gasLimit: '0x2710',


### PR DESCRIPTION
Looking in remix-lib/src/universalDapp.js, sendTransaction() looks like it only disallows mainnet transactions, but it calls silentRunTx() which does an additional check that makes sure you are using javascript VM. Updating readme to clarify this.

Also one of the example had a copy-paste error, calling client.solidity.on instead of client.udapp.on.