### PR TITLE
Adds id attribute to plugin iframes for easier testing

### DIFF
--- a/projects/engine/src/plugin/iframe.ts
+++ b/projects/engine/src/plugin/iframe.ts
@@ -116,6 +116,7 @@ export class IframePlugin extends ViewPlugin {
     }
     this.iframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-forms allow-top-navigation')
     this.iframe.setAttribute('seamless', 'true')
+    this.iframe.setAttribute('id', `frame-${this.name}`)
     this.iframe.src = transformUrl(this.profile.url)
     // Wait for the iframe to load and handshake
     this.iframe.onload = async () => {

--- a/projects/engine/src/plugin/iframe.ts
+++ b/projects/engine/src/plugin/iframe.ts
@@ -116,7 +116,7 @@ export class IframePlugin extends ViewPlugin {
     }
     this.iframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-forms allow-top-navigation')
     this.iframe.setAttribute('seamless', 'true')
-    this.iframe.setAttribute('id', `frame-${this.name}`)
+    this.iframe.setAttribute('id', `plugin-${this.name}`)
     this.iframe.src = transformUrl(this.profile.url)
     // Wait for the iframe to load and handshake
     this.iframe.onload = async () => {


### PR DESCRIPTION
I've been trying to add integration tests to my plugin, but using nightwatch you need to explicitly step into an iframe using .frame(). This would be a lot easier if we have a unique id to reference, so I added that using the plugin's name (which must be unique). Please let me know what you think.