### PR TITLE
reject error on call, not Error obj with string

### DIFF
--- a/projects/client/src/client.ts
+++ b/projects/client/src/client.ts
@@ -113,7 +113,7 @@ export class PluginClient<T extends Api = any, App extends ApiMap = RemixApi> im
       const callName = callEvent(name, key, this.id)
       this.events.once(callName, (result: any, error) => {
         error
-          ? rej(new Error(`Error from IDE : ${error}`))
+          ? rej(error)
           : res(result)
       })
       this.events.emit('send', { action: 'request', name, key, payload, id: this.id })


### PR DESCRIPTION
A follow-up to this request: https://github.com/ethereum/remix-ide/pull/2655
If the IDE returns a string as an error of a call, the remix-plugin-client should pass on the string to the plugin, instead of rejecting with new Error("Error from IDE ${error}") just reject with the string. This would enable the plugin either to parse the JSON and do something or just render the string. 