### PR TITLE
Plugin Option System

### DIFF
--- a/projects/engine/package.json
+++ b/projects/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remixproject/engine",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Plugin Engine that power Remix IDE",
   "contributors": [
     {

--- a/projects/engine/src/engine/engine.ts
+++ b/projects/engine/src/engine/engine.ts
@@ -283,7 +283,9 @@ export class Engine {
       }
       this.plugins[plugin.name] = plugin
       this.manager.addProfile(plugin.profile)
-      this.updateErrorHandler(plugin) // Update Error Handling for better debug
+       // Update Error Handling for better debug
+      this.updateErrorHandler(plugin)
+      // SetPluginOption is before onRegistration to let plugin update it's option inside onRegistration
       if (this.setPluginOption) {
         const options = this.setPluginOption(plugin.profile)
         plugin.setOptions(options)

--- a/projects/engine/src/engine/engine.ts
+++ b/projects/engine/src/engine/engine.ts
@@ -1,6 +1,6 @@
 import { BasePluginManager } from "../plugin/manager"
-import { Plugin } from '../plugin/abstract'
-import { listenEvent, PluginApi } from "../../../utils"
+import { Plugin, PluginOptions } from '../plugin/abstract'
+import { listenEvent, PluginApi, Profile } from "../../../utils"
 
 export class Engine {
   private plugins: Record<string, Plugin> = {}
@@ -10,6 +10,8 @@ export class Engine {
 
   private managerLoaded: () => void
   onRegistration?(plugin: Plugin): void
+  /** Update the options of the plugin when beeing registered */
+  setPluginOption?(profile: Profile): PluginOptions
 
   constructor(private manager: BasePluginManager) {
     this.plugins['manager'] = manager
@@ -282,6 +284,10 @@ export class Engine {
       this.plugins[plugin.name] = plugin
       this.manager.addProfile(plugin.profile)
       this.updateErrorHandler(plugin) // Update Error Handling for better debug
+      if (this.setPluginOption) {
+        const options = this.setPluginOption(plugin.profile)
+        plugin.setOptions(options)
+      }
       if (plugin.onRegistration) plugin.onRegistration()
       if (this.onRegistration) this.onRegistration(plugin)
       return plugin.name

--- a/projects/engine/src/plugin/external.ts
+++ b/projects/engine/src/plugin/external.ts
@@ -1,6 +1,6 @@
 import { ExternalProfile, Profile } from '../../../utils/src/types/profile'
 import { Message } from '../../../utils/src/types/message'
-import { Plugin } from './abstract'
+import { Plugin, PluginOptions } from './abstract'
 
 /** List of available gateways for decentralised storage */
 export const defaultGateways = {
@@ -9,16 +9,20 @@ export const defaultGateways = {
 }
 
 /** Transform the URL to use a gateway if decentralised storage is specified */
-export function transformUrl(url: string, name: string) {
+export function transformUrl({ url, name }: Profile & ExternalProfile) {
   const network = Object.keys(defaultGateways).find(key => url.startsWith(key))
   return network ? defaultGateways[network](url, name) : url
 }
 
+export interface ExternalPluginOptions extends PluginOptions {
+  transformUrl: (profile: Profile & ExternalProfile) => string
+}
 
 export abstract class ExternalPlugin extends Plugin {
   protected loaded: boolean
   protected id = 0
   protected pendingRequest: Record<number, (result: any, error: Error | string) => void> = {}
+  protected options: Partial<ExternalPluginOptions> = { transformUrl }
   profile: Profile & ExternalProfile
   constructor(profile: Profile & ExternalProfile) {
     super(profile)
@@ -29,6 +33,11 @@ export abstract class ExternalPlugin extends Plugin {
   deactivate() {
     this.loaded = false
     super.deactivate()
+  }
+
+  /** Set options for an external plugin */
+  setOptions(options: Partial<ExternalPluginOptions> = {}) {
+    super.setOptions(options)
   }
 
   /** Call a method from this plugin */

--- a/projects/engine/src/plugin/external.ts
+++ b/projects/engine/src/plugin/external.ts
@@ -4,8 +4,8 @@ import { Plugin, PluginOptions } from './abstract'
 
 /** List of available gateways for decentralised storage */
 export const defaultGateways = {
-  'ipfs://': (url, name) => `https://${name}.dyn.plugin.remixproject.org/ipfs/${url.replace('ipfs://','')}`,
-  'swarm://': (url, name) => `https://swarm-gateways.net/bzz-raw://${url.replace('swarm://','')}`
+  'ipfs://': (url, name) => `https://${name}.dyn.plugin.remixproject.org/ipfs/${url.replace('ipfs://', '')}`,
+  'swarm://': (url, name) => `https://swarm-gateways.net/bzz-raw://${url.replace('swarm://', '')}`
 }
 
 /** Transform the URL to use a gateway if decentralised storage is specified */

--- a/projects/engine/src/plugin/iframe.ts
+++ b/projects/engine/src/plugin/iframe.ts
@@ -1,6 +1,6 @@
 import { ViewPlugin } from './view'
 import { Message, ExternalProfile, Profile, LocationProfile } from '../../../utils'
-import { ExternalPlugin, transformUrl } from './external'
+import { ExternalPlugin } from './external'
 
 type MessageListener = ['message', (e: MessageEvent) => void, false]
 
@@ -63,7 +63,7 @@ export class IframePlugin extends ExternalPlugin implements ViewPlugin {
     this.iframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-forms allow-top-navigation')
     this.iframe.setAttribute('seamless', 'true')
     this.iframe.setAttribute('id', `plugin-${this.name}`)
-    this.iframe.src = transformUrl(this.profile.url, this.name)
+    this.iframe.src = this.options.transformUrl ? this.options.transformUrl(this.profile) : this.profile.url
     // Wait for the iframe to load and handshake
     this.iframe.onload = async () => {
       if (!this.iframe.contentWindow) {

--- a/projects/engine/src/plugin/manager.ts
+++ b/projects/engine/src/plugin/manager.ts
@@ -7,15 +7,15 @@ export type BasePluginManager = {
   updateProfile(profile: Partial<Profile>): any
   activatePlugin(name: string): any
   deactivatePlugin(name: string): any
-  // Internal
   isActive(name: string): Promise<boolean>
+  canCall(from: Profile, to: Profile, method: string): Promise<boolean>
+  // Internal
   toggleActive(name: string): any
   addProfile(profile: Partial<Profile>): any
-  canCall(from: Profile, to: Profile, method: string): Promise<boolean>
   canActivate(from: Profile, to: Profile): Promise<boolean>
 } & Plugin
 
-export const managerMethods = ['getProfile', 'updateProfile', 'activatePlugin', 'deactivatePlugin', 'canCall']
+export const managerMethods = ['getProfile', 'updateProfile', 'activatePlugin', 'deactivatePlugin', 'isActive', 'canCall']
 
 interface ManagerProfile extends Profile {
   name: 'manager',

--- a/projects/engine/tests/engine.ts
+++ b/projects/engine/tests/engine.ts
@@ -5,6 +5,7 @@ import { PluginManager } from '../src/plugin/manager'
 
 export class MockEngine extends Engine {
   onRegistration = jest.fn()
+  setPluginOption = jest.fn(() => ({ queueTimeout: 10000 }))
 }
 
 export class MockManager extends PluginManager {
@@ -87,6 +88,16 @@ describe('Registration with Engine', () => {
     expect(engine.onRegistration).toHaveBeenCalledTimes(2)
     expect(manager.onProfileAdded).toHaveBeenCalledTimes(2)
     expect(solidity.onRegistration).toHaveBeenCalledTimes(1)
+  })
+
+  test('Call setPluginOption on registration', async () => {
+    const manager = new MockManager()
+    const engine = new MockEngine(manager)
+    const solidity = new MockSolidity()
+    await engine.onload()
+    engine.register([solidity, new MockFileManager()])
+    expect(engine.setPluginOption).toHaveBeenCalledWith(solidity.profile)
+    expect(solidity['options'].queueTimeout).toBe(10000)
   })
 })
 

--- a/projects/engine/tests/plugins/external.ts
+++ b/projects/engine/tests/plugins/external.ts
@@ -2,12 +2,12 @@ import { transformUrl } from '../../src/plugin/external'
 
 describe('transform Url', () => {
   test('use gateway for swarm', () => {
-    expect(transformUrl('swarm://url', 'my_name')).toEqual('https://swarm-gateways.net/bzz-raw://url')
+    expect(transformUrl({ url: 'swarm://url', name: 'my_name'})).toEqual('https://swarm-gateways.net/bzz-raw://url')
   })
   test('use gateway for ipfs', () => {
-    expect(transformUrl('ipfs://url', 'my_name')).toEqual('https://my_name.dyn.plugin.remixproject.org/ipfs/url')
+    expect(transformUrl({ url: 'ipfs://url', name: 'my_name'})).toEqual('https://my_name.dyn.plugin.remixproject.org/ipfs/url')
   })
   test('use normal if provided', () => {
-    expect(transformUrl('https://url', 'my_name')).toEqual('https://url')
+    expect(transformUrl({ url: 'https://url', name: 'my_name' })).toEqual('https://url')
   })
 })


### PR DESCRIPTION
Create an option system on plugins : 
- Each plugin type can have specific option (extranal plugins have transformUrl for example).
- Engine has `addPluginOption` to apply global options to each plugin
- A plugin can override global options with `setOptions` (can be used inside `onRegistration` for example).

Here is the life cycle of plugin options
1. option is set in the plugin constructor
2. engine update options with `addPluginOption`
3. plugin can update options within `onRegistration`
