### PR TITLE
Fix vscode bug on deactivation

### DIFF
--- a/packages/engine/core/src/lib/abstract.ts
+++ b/packages/engine/core/src/lib/abstract.ts
@@ -108,6 +108,7 @@ export class Plugin<T extends Api = any, App extends ApiMap = any> implements Pl
           if (timedout) return
           resolve(result)
         } catch (err) {
+          delete this.currentRequest
           reject(err)
         }
         clearTimeout(ref)

--- a/packages/engine/vscode/src/lib/webview.ts
+++ b/packages/engine/vscode/src/lib/webview.ts
@@ -29,9 +29,7 @@ export class WebviewPlugin extends PluginConnector {
   }
 
   protected send(message: Partial<Message>): void {
-    if (this.panel) {
-      this.panel.webview.postMessage(message)
-    }
+    this.panel?.webview.postMessage(message)
   }
 
   protected connect(url: string): void {


### PR DESCRIPTION
Previous behavior: 
when a plugin try to deactivate a plugin the manager ask for the plugin permission. Even if the plugin ask self deactivation

New behavior :
when a plugin call manager for self deactivation, no need to ask back the plugin for permission.