### PR TITLE
Bunsenstraat patch 1

### DIFF
--- a/packages/api/src/lib/compiler/api.ts
+++ b/packages/api/src/lib/compiler/api.ts
@@ -1,4 +1,4 @@
-import { CompilationResult, CompilationFileSources, lastCompilationResult } from './type';
+import { CompilationResult, CompilationFileSources, lastCompilationResult } from './type'
 import { StatusEvents, Api } from '@remixproject/plugin-utils'
 
 export interface ICompiler extends Api {

--- a/packages/api/src/lib/compiler/api.ts
+++ b/packages/api/src/lib/compiler/api.ts
@@ -1,4 +1,4 @@
-import { CompilationResult, CompilationFileSources } from './type'
+import { CompilationResult, CompilationFileSources, lastCompilationResult } from './type';
 import { StatusEvents, Api } from '@remixproject/plugin-utils'
 
 export interface ICompiler extends Api {
@@ -11,7 +11,7 @@ export interface ICompiler extends Api {
     ) => void
   } & StatusEvents
   methods: {
-    getCompilationResult(): CompilationResult
+    getCompilationResult(): lastCompilationResult
     compile(fileName: string): void
   }
 }

--- a/packages/api/src/lib/compiler/type/output.ts
+++ b/packages/api/src/lib/compiler/type/output.ts
@@ -2,9 +2,20 @@
 // SOURCES //
 /////////////
 export interface CompilationFileSources {
-  [fileName: string]: { content: string }
+    [fileName: string]:
+        {
+        // Optional: keccak256 hash of the source file
+        keccak256?: string,
+        // Required (unless "urls" is used): literal contents of the source file
+        content: string,
+        urls?: string[]
+        }
 }
 
+export interface SourceWithTarget {
+    sources?: CompilationFileSources,
+    target?: string | null | undefined
+}
 
 ////////////
 // RESULT //
@@ -25,6 +36,11 @@ export interface CompilationResult {
     }
   }
 }
+
+export interface lastCompilationResult {
+    data: CompilationResult | null;
+    source: SourceWithTarget | null | undefined;
+} 
 
 ///////////
 // ERROR //

--- a/packages/api/src/lib/compiler/type/output.ts
+++ b/packages/api/src/lib/compiler/type/output.ts
@@ -38,8 +38,8 @@ export interface CompilationResult {
 }
 
 export interface lastCompilationResult {
-    data: CompilationResult | null;
-    source: SourceWithTarget | null | undefined;
+    data: CompilationResult | null
+    source: SourceWithTarget | null | undefined
 } 
 
 ///////////


### PR DESCRIPTION
The object returned by getCompilationResult is not of type CompilationResult but of type lastCompilationResult which contains CompilationResult as data

```
export interface lastCompilationResult {
    data: CompilationResult | null;
    source: SourceWithTarget | null | undefined;
} 
```