### PR TITLE
createclient should return new pluginClient if none is provided as args in JS

### DIFF
--- a/packages/plugin/webview/src/lib/connector.ts
+++ b/packages/plugin/webview/src/lib/connector.ts
@@ -91,14 +91,14 @@ export const createClient = <
   C extends PluginClient<P, App> = any
 >(client: C): C & PluginApi<App> => {
   const c = client as any || new PluginClient<P, App>()
-  const options = client.options
+  const options = c.options
   const connector = new WebviewConnector(options)
   connectClient(connector, c)
   applyApi(c)
   if (!options.customTheme) {
     listenOnThemeChanged(c)
   }
-  return client as any
+  return c as any
 }
 
 /** Set the theme variables in the :root */


### PR DESCRIPTION
This only happens when using JS, not in TS. There you can pass anything or nothing. But in case it's nothing it should also return the new client, once it's been created if nothing is passed right? otherwise, you pass nothing, you get nothing back, you should get a new client instance.