### PR TITLE
content type for import to any

### DIFF
--- a/packages/api/src/lib/content-import/type.ts
+++ b/packages/api/src/lib/content-import/type.ts
@@ -1,5 +1,5 @@
 export interface ContentImport {
-  content: string
+  content: any
   cleanUrl: string
   type: 'github' | 'http' | 'https' | 'swarm' | 'ipfs'
   url: string


### PR DESCRIPTION
https://github.com/ethereum/remix-project/issues/772
Because the resolver uses axios which could return parsed JSON