### PR TITLE
fix for opening files and getting current file

### DIFF
--- a/packages/engine/vscode/src/lib/filemanager.ts
+++ b/packages/engine/vscode/src/lib/filemanager.ts
@@ -1,8 +1,9 @@
 import { filSystemProfile, IFileSystem } from '@remixproject/plugin-api'
 import { MethodApi } from '@remixproject/plugin-utils'
-import { window, workspace, Uri, commands } from 'vscode'
+import { window, workspace, Uri, commands, ViewColumn } from 'vscode'
 import { CommandPlugin } from './command'
 import { absolutePath, relativePath } from '../util/path'
+import { getOpenedTextEditor } from '../util/editor'
 
 export class FileManagerPlugin extends CommandPlugin implements MethodApi<IFileSystem> {
   constructor() {
@@ -12,7 +13,7 @@ export class FileManagerPlugin extends CommandPlugin implements MethodApi<IFileS
   async open(path: string): Promise<void> {
     const absPath = absolutePath(path)
     const uri = Uri.file(absPath)
-    return commands.executeCommand('vscode.open', uri)
+    return commands.executeCommand('vscode.open', uri, { viewColumn: ( getOpenedTextEditor()?.viewColumn || ViewColumn.One ) })
   }
   /** Set the content of a specific file */
   async writeFile(path: string, data: string): Promise<void> {
@@ -59,7 +60,8 @@ export class FileManagerPlugin extends CommandPlugin implements MethodApi<IFileS
   }
 
   async getCurrentFile() {
-    const fileName = window.activeTextEditor ? window.activeTextEditor.document.fileName : undefined
+    const fileName = (getOpenedTextEditor()?.document?.fileName || undefined)
+    if(!fileName) throw new Error("No current file found.")
     return relativePath(fileName)
   }
   // ------------------------------------------

--- a/packages/engine/vscode/src/util/editor.ts
+++ b/packages/engine/vscode/src/util/editor.ts
@@ -10,12 +10,12 @@ export function getOpenedTextEditor() {
 
 export function getTextEditorWithDocumentType(type: string) {
   const editors: TextEditor[] = window.visibleTextEditors;
-  const fileeditor: TextEditor = editors.find(
+  const fileEditor: TextEditor = editors.find(
     (editor) =>
       editor.document &&
       editor.document.uri &&
       editor.document.uri.scheme &&
       editor.document.uri.scheme == type
   );
-  return fileeditor;
+  return fileEditor;
 }

--- a/packages/engine/vscode/src/util/editor.ts
+++ b/packages/engine/vscode/src/util/editor.ts
@@ -1,0 +1,21 @@
+import { TextEditor, window } from 'vscode';
+
+export function getOpenedTextEditor() {
+  if (!window.activeTextEditor) {
+    return getTextEditorWithDocumentType('file');
+  } else {
+    return window.activeTextEditor;
+  }
+}
+
+export function getTextEditorWithDocumentType(type: string) {
+  const editors: TextEditor[] = window.visibleTextEditors;
+  const fileeditor: TextEditor = editors.find(
+    (editor) =>
+      editor.document &&
+      editor.document.uri &&
+      editor.document.uri.scheme &&
+      editor.document.uri.scheme == type
+  );
+  return fileeditor;
+}


### PR DESCRIPTION
the window.activeTextEditor is often undefined when interacting with a plugin through clicks for example, because it is no longer active. This means using that to open a file or getting the current file will not work.

The solution is to find all the visibleTextEditors that have a document in it with a scheme of 'file' and open the file in with the 
TextDocumentShowOptions vielColunm property set to the viewcolumn of either the active editor or the first editor found that has a file in it
https://vshaxe.github.io/vscode-extern/vscode/TextDocumentShowOptions.html

to get the current file, the only option is to just to assume the first editor found with a file in it will be current, although you can have multiple columns open with files, when you lose focus there is no way of knowing which one is current.
it is important to note that if an editor has an unsaved empty untitled file in it, it is not viewed as editor with a file opened.

there is big caveat: if the plugin has focus in the same column as the files, for example when it is a mainpanel plugin, it will never find either activeeditor or texteditors opened. so for getcurrentfile it will never find the file. for openfile it will just open in the same column.

