### PR TITLE
Plugindata

### DIFF
--- a/packages/engine/vscode/src/index.ts
+++ b/packages/engine/vscode/src/index.ts
@@ -8,3 +8,4 @@ export * from './lib/filemanager';
 export * from './lib/editor';
 export * from './lib/terminal';
 export * from './lib/contentimport';
+export * from './lib/appmanager';

--- a/packages/engine/vscode/src/lib/appmanager.ts
+++ b/packages/engine/vscode/src/lib/appmanager.ts
@@ -1,0 +1,21 @@
+import { PluginManager } from "@remixproject/engine"
+import axios from 'axios'
+export class VscodeAppManager extends PluginManager {
+    pluginsDirectory:string
+    target:string
+    constructor () {
+      super()
+      this.pluginsDirectory = 'https://raw.githubusercontent.com/ethereum/remix-plugins-directory/master/build/metadata.json'
+      this.target = "vscode"
+    }
+
+    async registeredPluginData () {
+        let plugins
+        try {
+            plugins = await axios.get(this.pluginsDirectory)
+            return plugins.data.filter((p:any)=>(p.targets && p.targets.includes(this.target)))
+          } catch (e) {
+            throw new Error("Could not fetch plugin profiles.")
+          }
+    }
+}

--- a/packages/engine/vscode/src/lib/filemanager.ts
+++ b/packages/engine/vscode/src/lib/filemanager.ts
@@ -1,8 +1,9 @@
 import { filSystemProfile, IFileSystem } from '@remixproject/plugin-api'
 import { MethodApi } from '@remixproject/plugin-utils'
-import { window, workspace, Uri, commands } from 'vscode'
+import { window, workspace, Uri, commands, ViewColumn } from 'vscode'
 import { CommandPlugin } from './command'
 import { absolutePath, relativePath } from '../util/path'
+import { getOpenedTextEditor } from '../util/editor'
 
 export class FileManagerPlugin extends CommandPlugin implements MethodApi<IFileSystem> {
   constructor() {
@@ -12,7 +13,7 @@ export class FileManagerPlugin extends CommandPlugin implements MethodApi<IFileS
   async open(path: string): Promise<void> {
     const absPath = absolutePath(path)
     const uri = Uri.file(absPath)
-    return commands.executeCommand('vscode.open', uri)
+    return commands.executeCommand('vscode.open', uri, { viewColumn: ( getOpenedTextEditor()?.viewColumn || ViewColumn.One ) })
   }
   /** Set the content of a specific file */
   async writeFile(path: string, data: string): Promise<void> {
@@ -59,7 +60,8 @@ export class FileManagerPlugin extends CommandPlugin implements MethodApi<IFileS
   }
 
   async getCurrentFile() {
-    const fileName = window.activeTextEditor ? window.activeTextEditor.document.fileName : undefined
+    const fileName = (getOpenedTextEditor()?.document?.fileName || undefined)
+    if(!fileName) throw new Error("No current file found.")
     return relativePath(fileName)
   }
   // ------------------------------------------

--- a/packages/engine/vscode/src/lib/webview.ts
+++ b/packages/engine/vscode/src/lib/webview.ts
@@ -6,7 +6,7 @@ import { promises as fs, watch } from 'fs'
 import { get } from 'https'
 import { parse as parseUrl } from 'url'
 
-interface WebviewOptions extends PluginConnectorOptions {
+export interface WebviewOptions extends PluginConnectorOptions {
   /** Extension Path */
   context: ExtensionContext
   relativeTo?: 'workspace' | 'extension'

--- a/packages/engine/vscode/src/util/editor.ts
+++ b/packages/engine/vscode/src/util/editor.ts
@@ -1,0 +1,21 @@
+import { TextEditor, window } from 'vscode';
+
+export function getOpenedTextEditor() {
+  if (!window.activeTextEditor) {
+    return getTextEditorWithDocumentType('file');
+  } else {
+    return window.activeTextEditor;
+  }
+}
+
+export function getTextEditorWithDocumentType(type: string) {
+  const editors: TextEditor[] = window.visibleTextEditors;
+  const fileeditor: TextEditor = editors.find(
+    (editor) =>
+      editor.document &&
+      editor.document.uri &&
+      editor.document.uri.scheme &&
+      editor.document.uri.scheme == type
+  );
+  return fileeditor;
+}


### PR DESCRIPTION
Vscode engine now supports fetching the plugin data directly from the repo. It filters it on the targets property, which is an array of supported engine targets: ['vscode']