### PR TITLE
Fixthemes

### DIFF
--- a/packages/plugin/webview/src/lib/connector.ts
+++ b/packages/plugin/webview/src/lib/connector.ts
@@ -156,21 +156,24 @@ function applyTheme(theme: Theme) {
 
 /** Start listening on theme changed */
 async function listenOnThemeChanged(client: PluginClient) {
-  let cssLink: HTMLLinkElement;
+  let cssHttpLink: HTMLLinkElement;
+  let cssHttpsLink: HTMLLinkElement;
   // Memorized the css link but only create it when needed
-  const getLink = () => {
-    if (!cssLink) {
-      cssLink = document.createElement('link')
-      cssLink.setAttribute('rel', 'stylesheet')
-      document.head.prepend(cssLink)
+  const getLink = (element) => {
+    if (!element) {
+      element = document.createElement('link')
+      element.setAttribute('rel', 'stylesheet')
+      document.head.prepend(element)
     }
-    return cssLink;
+    return element;
   }
 
   // If there is a url in the theme, use it
   const setLink = (theme: Theme) => {
     if (theme.url) {
-      getLink().setAttribute('href', theme.url.replace(/^http:/,"").replace(/^https:/,""))
+      const url = theme.url.replace(/^http:/, "protocol:").replace(/^https:/, "protocol:");
+      getLink(cssHttpLink).setAttribute('href', url.replace(/^protocol:/, "http:"));
+      getLink(cssHttpsLink).setAttribute('href', url.replace(/^protocol:/, "https:"));
       document.documentElement.style.setProperty('--theme', theme.quality)
     }
   }
@@ -186,6 +189,5 @@ async function listenOnThemeChanged(client: PluginClient) {
     setLink(theme);
     applyTheme(theme);
   })
-  return cssLink
+  return cssHttpsLink
 }
-


### PR DESCRIPTION
This actually puts 2 css links in the plugin webviews, https and non https.  This fixes all mixed origin situations, for example running localhost with a plugin that is on https.  We cannot know in webview what is going on, this a bruteforce way of doing it. We could also start comparing urls of the plugin profile and the incoming css url of course... but this works... suggestions are welcome. 