### PR TITLE
Update connector.ts

### DIFF
--- a/packages/plugin/core/src/lib/connector.ts
+++ b/packages/plugin/core/src/lib/connector.ts
@@ -69,9 +69,6 @@ export function connectClient(connector: ClientConnector, client: PluginClient =
         case 'request': {
           const path = requestInfo && requestInfo.path
           const method = getMethodPath(key, path)
-          if (!client.methods) {
-            throw new Error(`Client should define a list of methods to make available`)
-          }
           if (!client[method]) {
             throw new Error(`Method ${method} doesn't exist on plugin ${name}`)
           }


### PR DESCRIPTION
This forced plugins to always specify methods [], even just an empty, which is useless unless you enforce the method called to be in the array. But we encountered problems with this approach unless every single plugin in the system exposes such a methods [].