### PR TITLE
Update connector.ts

### DIFF
--- a/packages/engine/core/src/lib/connector.ts
+++ b/packages/engine/core/src/lib/connector.ts
@@ -89,7 +89,7 @@ export abstract class PluginConnector extends Plugin {
       }
       if (methods) {
         this.profile.methods = methods
-        await this.call('manager', 'updateProfile', this.profile)
+        this.call('manager', 'updateProfile', this.profile)
       }
     } else {
       // If there is a broken connection we want send back the handshake to the plugin client


### PR DESCRIPTION
when you call 'manager' to activate something via a plugin call, this call gets queued in the engine. However the iframe plugin itself also calls manager during the activation to update its profile. But that call will only return when the first one, activatePlugin has finished. So it waits, activatePugin times out and then updateProfile is executed. This only happens however when a plugin has methods. To update the profile in the manager.