### PR TITLE
fix readme error

### DIFF
--- a/packages/plugin/core/README.md
+++ b/packages/plugin/core/README.md
@@ -33,7 +33,7 @@ npm install @remixproject/plugin-iframe
 
 or with a unpkg :
 ```html
-<script src="https://unpkg.com/@remixproject/plugin"></script>
+<script src="https://unpkg.com/@remixproject/plugin-iframe"></script>
 ```
 
 ### Plugin Client
@@ -41,7 +41,7 @@ The plugin client is how you connect your plugin to remix.
 
 To import ( the ES6 way) with NPM use:
 ```javascript
-import { createClient } from '@remixproject/plugin'
+import { createClient } from '@remixproject/plugin-iframe'
 const client = createClient()
 ```
 Or if you are using unpkg use:

--- a/packages/plugin/iframe/README.md
+++ b/packages/plugin/iframe/README.md
@@ -20,7 +20,7 @@ client.onload(async () => {
 If you need to expose an API to other plugin you need to extends the class: 
 ```typescript
 import { createClient } from '@remixproject/plugin-iframe'
-import { PluginClient } from '@rexmixproject/plugin'
+import { PluginClient } from '@remixproject/plugin'
 
 class MyPlugin extends PluginClient {
   methods = ['hello']
@@ -28,7 +28,7 @@ class MyPlugin extends PluginClient {
     console.log('Hello World')
   }
 }
-const client = createClient()
+const client = createClient(new MyPlugin())
 client.onload(async () => {
   const data = client.call('filemanager', 'readFile', 'ballot.sol')
 })


### PR DESCRIPTION
There is another problem that I can't fix. 

This link `https://unpkg.com/@remixproject/plugin-iframe` will redirect to an incorrect link `https://unpkg.com/@remixproject/plugin-iframe@0.3.31/src/index.js`. 

The correct link shoud be `https://unpkg.com/@remixproject/plugin-iframe@0.3.31/index.js`, which dosen't have `src` in it. 

You may need to config somehow to fix the redirect issue.

@bunsenstraat @yann300 @LianaHus @ryestew 