### PR TITLE
Add allow-popups-to-escape-sandbox to sandbox attribute of iframes

### DIFF
--- a/packages/engine/vscode/src/lib/webview.ts
+++ b/packages/engine/vscode/src/lib/webview.ts
@@ -214,7 +214,7 @@ async function getWebviewContent(url: string, profile: Profile, options: Webview
             }
       });
       
-      pframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-downloads allow-forms allow-top-navigation')
+      pframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-downloads allow-forms allow-top-navigation allow-popups-to-escape-sandbox')
       pframe.setAttribute('seamless', 'true')
       pframe.src = '${serverUri}?r=${Math.random()}'
       pframe.setAttribute('id', 'plugin-${profile.name}')

--- a/packages/engine/web/src/lib/iframe.ts
+++ b/packages/engine/web/src/lib/iframe.ts
@@ -73,7 +73,7 @@ disconnect() {
     if (this.iframe.contentWindow) {
       throw new Error(`${this.name} plugin is already rendered`)
     }
-    this.iframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-forms allow-top-navigation')
+    this.iframe.setAttribute('sandbox', 'allow-popups allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups-to-escape-sandbox')
     this.iframe.setAttribute('seamless', 'true')
     this.iframe.setAttribute('id', `plugin-${this.name}`)
     this.iframe.src = this.url


### PR DESCRIPTION
Needed for opening links to sites with `cross-origin-opener-policy: same-origin` header in the response.

We had this issue in the contract verification plugin with links to Blockscout. See https://github.com/ethereum/sourcify/issues/1530