### PR TITLE
updated list of evm versions

### DIFF
--- a/packages/api/src/lib/compiler/type/input.ts
+++ b/packages/api/src/lib/compiler/type/input.ts
@@ -11,7 +11,19 @@ export interface CondensedCompilationInput {
   optimize: boolean
   /** e.g: 0.6.8+commit.0bbfe453 */
   version: string
-  evmVersion?: 'istanbul' | 'petersburg' | 'constantinople' | 'byzantium' | 'spuriousDragon' | 'tangerineWhistle' | 'homestead'
+  evmVersion?:
+    | 'cancun'
+    | 'shanghai'
+    | 'paris'
+    | 'london'
+    | 'berlin'
+    | 'istanbul'
+    | 'petersburg'
+    | 'constantinople'
+    | 'byzantium'
+    | 'spuriousDragon'
+    | 'tangerineWhistle'
+    | 'homestead'
 }
 
 /////////////
@@ -50,6 +62,11 @@ export interface CompilerSettings {
   optimizer?: Partial<CompilerOptimizer>
   /** Version of the EVM to compile for. Affects type checking and code generation */
   evmVersion:
+    | 'cancun'
+    | 'shanghai'
+    | 'paris'
+    | 'london'
+    | 'berlin'
     | 'homestead'
     | 'tangerineWhistle'
     | 'spuriousDragon'


### PR DESCRIPTION
The list of supported EVM versions is out of date and thus currently requires a workaround of suppressing the TypeScript compiler error to use EVM versions such as Paris.